### PR TITLE
Add 10s delay to destroy of the vpc

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -44,3 +44,22 @@ provider "registry.terraform.io/hashicorp/local" {
     "zh:ef34c52b68933bedd0868a13ccfd59ff1c820f299760b3c02e008dc95e2ece91",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/time" {
+  version = "0.12.1"
+  hashes = [
+    "h1:JzYsPugN8Fb7C4NlfLoFu7BBPuRVT2/fCOdCaxshveI=",
+    "zh:090023137df8effe8804e81c65f636dadf8f9d35b79c3afff282d39367ba44b2",
+    "zh:26f1e458358ba55f6558613f1427dcfa6ae2be5119b722d0b3adb27cd001efea",
+    "zh:272ccc73a03384b72b964918c7afeb22c2e6be22460d92b150aaf28f29a7d511",
+    "zh:438b8c74f5ed62fe921bd1078abe628a6675e44912933100ea4fa26863e340e9",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:85c8bd8eefc4afc33445de2ee7fbf33a7807bc34eb3734b8eefa4e98e4cddf38",
+    "zh:98bbe309c9ff5b2352de6a047e0ec6c7e3764b4ed3dfd370839c4be2fbfff869",
+    "zh:9c7bf8c56da1b124e0e2f3210a1915e778bab2be924481af684695b52672891e",
+    "zh:d2200f7f6ab8ecb8373cda796b864ad4867f5c255cff9d3b032f666e4c78f625",
+    "zh:d8c7926feaddfdc08d5ebb41b03445166df8c125417b28d64712dccd9feef136",
+    "zh:e2412a192fc340c61b373d6c20c9d805d7d3dee6c720c34db23c2a8ff0abd71b",
+    "zh:e6ac6bba391afe728a099df344dbd6481425b06d61697522017b8f7a59957d44",
+  ]
+}

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,13 @@ resource "digitalocean_vpc" "droplets-network" {
   region = var.region_server
 }
 
+resource "time_sleep" "wait_10_seconds_to_destroy_vpc" {
+  depends_on = [digitalocean_vpc.droplets-network]
+  destroy_duration = "10s"
+}
+
 resource "digitalocean_droplet" "rancherserver" {
+  depends_on = [time_sleep.wait_10_seconds_to_destroy_vpc]
   count    = "1"
   image    = var.image_server
   name     = "${var.prefix}-rancherserver"
@@ -37,6 +43,7 @@ resource "digitalocean_droplet" "rancherserver" {
 }
 
 resource "digitalocean_droplet" "rancheragent-all" {
+  depends_on = [time_sleep.wait_10_seconds_to_destroy_vpc]
   count    = var.count_agent_all_nodes
   image    = var.image_agent
   name     = "${var.prefix}-rancheragent-all-${count.index}"
@@ -57,6 +64,7 @@ resource "digitalocean_droplet" "rancheragent-all" {
 }
 
 resource "digitalocean_droplet" "rancheragent-master" {
+  depends_on = [time_sleep.wait_10_seconds_to_destroy_vpc]
   count    = var.count_agent_master_nodes
   image    = var.image_agent
   name     = "${var.prefix}-rancheragent-master-${count.index}"
@@ -77,6 +85,7 @@ resource "digitalocean_droplet" "rancheragent-master" {
 }
 
 resource "digitalocean_droplet" "rancheragent-etcd" {
+  depends_on = [time_sleep.wait_10_seconds_to_destroy_vpc]
   count    = var.count_agent_etcd_nodes
   image    = var.image_agent
   name     = "${var.prefix}-rancheragent-etcd-${count.index}"
@@ -97,6 +106,7 @@ resource "digitalocean_droplet" "rancheragent-etcd" {
 }
 
 resource "digitalocean_droplet" "rancheragent-controlplane" {
+  depends_on = [time_sleep.wait_10_seconds_to_destroy_vpc]
   count    = var.count_agent_controlplane_nodes
   image    = var.image_agent
   name     = "${var.prefix}-rancheragent-controlplane-${count.index}"
@@ -117,6 +127,7 @@ resource "digitalocean_droplet" "rancheragent-controlplane" {
 }
 
 resource "digitalocean_droplet" "rancheragent-worker" {
+  depends_on = [time_sleep.wait_10_seconds_to_destroy_vpc]
   count    = var.count_agent_worker_nodes
   image    = var.image_agent
   name     = "${var.prefix}-rancheragent-worker-${count.index}"
@@ -137,6 +148,7 @@ resource "digitalocean_droplet" "rancheragent-worker" {
 }
 
 resource "digitalocean_droplet" "rancher-tools" {
+  depends_on = [time_sleep.wait_10_seconds_to_destroy_vpc]
   count    = var.count_tools_nodes
   image    = var.image_tools
   name     = "${var.prefix}-rancher-tools-${count.index}"
@@ -151,6 +163,7 @@ resource "digitalocean_droplet" "rancher-tools" {
 }
 
 resource "digitalocean_droplet" "rancheragent-rke2-all" {
+  depends_on = [time_sleep.wait_10_seconds_to_destroy_vpc]
   count    = var.count_rke2_agent_all_nodes
   image    = var.image_agent
   name     = "${var.prefix}-rancheragent-rke2-all-${count.index}"
@@ -170,6 +183,7 @@ resource "digitalocean_droplet" "rancheragent-rke2-all" {
 }
 
 resource "digitalocean_droplet" "rancheragent-rke2-master" {
+  depends_on = [time_sleep.wait_10_seconds_to_destroy_vpc]
   count    = var.count_rke2_agent_master_nodes
   image    = var.image_agent
   name     = "${var.prefix}-rancheragent-rke2-master-${count.index}"
@@ -189,6 +203,7 @@ resource "digitalocean_droplet" "rancheragent-rke2-master" {
 }
 
 resource "digitalocean_droplet" "rancheragent-rke2-etcd" {
+  depends_on = [time_sleep.wait_10_seconds_to_destroy_vpc]
   count    = var.count_rke2_agent_etcd_nodes
   image    = var.image_agent
   name     = "${var.prefix}-rancheragent-rke2-etcd-${count.index}"
@@ -208,6 +223,7 @@ resource "digitalocean_droplet" "rancheragent-rke2-etcd" {
 }
 
 resource "digitalocean_droplet" "rancheragent-rke2-controlplane" {
+  depends_on = [time_sleep.wait_10_seconds_to_destroy_vpc]
   count    = var.count_rke2_agent_controlplane_nodes
   image    = var.image_agent
   name     = "${var.prefix}-rancheragent-rke2-controlplane-${count.index}"
@@ -227,6 +243,7 @@ resource "digitalocean_droplet" "rancheragent-rke2-controlplane" {
 }
 
 resource "digitalocean_droplet" "rancheragent-rke2-worker" {
+  depends_on = [time_sleep.wait_10_seconds_to_destroy_vpc]
   count    = var.count_rke2_agent_worker_nodes
   image    = var.image_agent
   name     = "${var.prefix}-rancheragent-rke2-worker-${count.index}"

--- a/versions.tf
+++ b/versions.tf
@@ -8,5 +8,8 @@ terraform {
     local = {
       source = "hashicorp/local"
     }
+    time = {
+      source = "hashicorp/time"
+    }
   }
 }


### PR DESCRIPTION
Add 10s delay to the deletion of the VPC to prevent errors of the format `Error: Error deleting VPC: DELETE https://api.digitalocean.com/v2/vpcs/2fa095eb-4724-4d8c-8700-aa07efd4e402: 409 (request "a0482671-73dd-4887-8058-e6f201b8cc91") Can not delete VPC with members`

https://github.com/digitalocean/terraform-provider-digitalocean/issues/446#issuecomment-1079621088